### PR TITLE
Add input support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This GitHub Action requests a branch deploy from [Cased](https://cased.com).
 - `branch_name`: The name of the branch to deploy. Defaults to 'main'.
 - `target`: The target environment for the deployment. Defaults to 'prod'.
 - `trigger`: The trigger for the deployment. Defaults to 'pr_merge'.
+- `workflow_inputs`: (optional, JSON string) Additional workflow input parameters to send to Cased. Example: '{"foo": "bar", "baz": 123}'
 
 The action will automatically send the pull request number if available.
 
@@ -34,3 +35,4 @@ jobs:
           branch_name: ${{ github.event.pull_request.base.ref }}
           target: 'feat/我的新分支'
           cased_token: ${{ secrets.CASED_TOKEN }}
+          workflow_inputs: '{"user_env": "acme", "ranges": "alpha,beta"}'

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   cased_token:
     description: 'Cased API token'
     required: true
+  workflow_inputs:
+    description: 'Additional workflow input parameters (as a JSON string)'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/index.py
+++ b/index.py
@@ -56,6 +56,15 @@ def main():
     else:
         print('Warning: Could not determine PR number')
 
+    workflow_inputs = os.getenv('INPUT_WORKFLOW_INPUTS')
+    if workflow_inputs:
+        try:
+            workflow_inputs_dict = json.loads(workflow_inputs)
+            data['workflow_inputs'] = workflow_inputs_dict
+        except Exception as e:
+            print(f'Invalid JSON for workflow_inputs: {e}')
+            sys.exit(1)
+
     headers = {
         'Authorization': f'Bearer {cased_token}',
         'Content-Type': 'application/json',


### PR DESCRIPTION
This pull request introduces support for passing additional workflow input parameters as a JSON string to the Cased deployment action. The changes include updates to the documentation, action metadata, and the main script to handle this new feature.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R11): Added a description for the new `workflow_inputs` parameter, including an example of its usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38)

### Action metadata updates:
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R19-R21): Added a new optional input parameter, `workflow_inputs`, with a description specifying that it accepts a JSON string.

### Script updates:
* [`index.py`](diffhunk://#diff-d568ca4e7eadfe7422397de0ed9269419d690f632aeb3e13826faefc79826ec9R59-R67): Updated the `main` function to read the `workflow_inputs` environment variable, parse it as JSON, and include it in the data sent to the Cased API. Added error handling for invalid JSON input.